### PR TITLE
Add Scryfall MCP server integration to GPT command

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -8,6 +8,7 @@ import { ChatId } from './types/chatIds';
 import { cardSearch } from './actions/commands/cardSearch';
 import { inlineCardSearch } from './actions/inline/inline_cardSearch';
 import { featureProvider } from './services/featureProvider';
+import { mcpClient } from './services/mcpClientService';
 
 await featureProvider.load();
 
@@ -85,10 +86,12 @@ if (process.env.NODE_ENV == 'production') {
 }
 
 process.once('SIGINT', async () => {
+    await mcpClient.disconnect();
     await botOrchestrator.stopBots();
     process.exit(0);
 });
 process.once('SIGTERM', async () => {
+    await mcpClient.disconnect();
     await botOrchestrator.stopBots();
     process.exit(0);
 });

--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
     "type": "module",
     "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2",
         "async-sema": "^3.1.1",
         "cheerio": "^1.0.0-rc.12",
         "chz-telegram-bot": "^0.5.5",
         "markdown-escape": "^2.0.0",
         "moment": "^2.30.1",
-        "openai": "^5.8.3"
+        "openai": "^5.8.3",
+        "zod": "^3.25.76"
     },
     "devDependencies": {
         "@eslint/js": "^9.10.0",

--- a/services/mcpClientService.ts
+++ b/services/mcpClientService.ts
@@ -1,0 +1,68 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+class McpClientService {
+    private client: Client | null = null;
+    private transport: StdioClientTransport | null = null;
+    private connecting: Promise<void> | null = null;
+
+    async connect(): Promise<void> {
+        if (this.client) return;
+
+        if (this.connecting) {
+            await this.connecting;
+            return;
+        }
+
+        this.connecting = this.doConnect();
+        await this.connecting;
+        this.connecting = null;
+    }
+
+    private async doConnect(): Promise<void> {
+        this.transport = new StdioClientTransport({
+            command: 'npx',
+            args: ['scryfall-mcp-server']
+        });
+
+        this.client = new Client(
+            { name: 'funnyBot', version: '1.0.0' },
+            { capabilities: {} }
+        );
+
+        await this.client.connect(this.transport);
+    }
+
+    async callTool(
+        name: string,
+        args: Record<string, unknown>
+    ): Promise<string> {
+        await this.connect();
+
+        if (!this.client) {
+            throw new Error('MCP client not connected');
+        }
+
+        const result = await this.client.callTool({ name, arguments: args });
+
+        const content = result.content;
+        if (Array.isArray(content) && content.length > 0) {
+            const first = content[0];
+            if (first.type === 'text') {
+                return first.text;
+            }
+        }
+
+        return JSON.stringify(content);
+    }
+
+    async disconnect(): Promise<void> {
+        if (this.client) {
+            await this.client.close();
+            this.client = null;
+        }
+        this.transport = null;
+    }
+}
+
+export const mcpClient = new McpClientService();

--- a/services/openAiToolsService.ts
+++ b/services/openAiToolsService.ts
@@ -1,0 +1,111 @@
+import type OpenAI from 'openai';
+import { mcpClient } from './mcpClientService';
+
+export const scryfallTools: OpenAI.Responses.Tool[] = [
+    {
+        type: 'function',
+        name: 'search_cards',
+        strict: null,
+        description:
+            'Search for Magic: The Gathering cards using Scryfall syntax. Returns matching cards with details.',
+        parameters: {
+            type: 'object',
+            properties: {
+                query: {
+                    type: 'string',
+                    description:
+                        'Scryfall search query (e.g., "lightning bolt", "c:red cmc:1", "t:creature pow>=5")'
+                }
+            },
+            required: ['query']
+        }
+    },
+    {
+        type: 'function',
+        name: 'get_card_by_name',
+        strict: null,
+        description:
+            'Get a specific Magic: The Gathering card by its exact name. Returns full card details including oracle text, mana cost, and prices.',
+        parameters: {
+            type: 'object',
+            properties: {
+                name: {
+                    type: 'string',
+                    description: 'Exact card name (e.g., "Black Lotus", "Counterspell")'
+                },
+                set_code: {
+                    type: 'string',
+                    description: 'Optional 3-letter set code (e.g., "lea", "2ed")'
+                }
+            },
+            required: ['name']
+        }
+    },
+    {
+        type: 'function',
+        name: 'get_rulings',
+        strict: null,
+        description:
+            'Get official rulings for a Magic: The Gathering card. Returns Oracle rulings and errata.',
+        parameters: {
+            type: 'object',
+            properties: {
+                card_name: {
+                    type: 'string',
+                    description: 'Name of the card to get rulings for'
+                }
+            },
+            required: ['card_name']
+        }
+    },
+    {
+        type: 'function',
+        name: 'get_prices_by_name',
+        strict: null,
+        description:
+            'Get current market prices for a Magic: The Gathering card from multiple marketplaces.',
+        parameters: {
+            type: 'object',
+            properties: {
+                name: {
+                    type: 'string',
+                    description: 'Card name to look up prices for'
+                },
+                set_code: {
+                    type: 'string',
+                    description: 'Optional set code to get prices for specific printing'
+                }
+            },
+            required: ['name']
+        }
+    },
+    {
+        type: 'function',
+        name: 'random_card',
+        strict: null,
+        description:
+            'Get a random Magic: The Gathering card, optionally filtered by a query.',
+        parameters: {
+            type: 'object',
+            properties: {
+                query: {
+                    type: 'string',
+                    description:
+                        'Optional Scryfall query to filter random selection (e.g., "c:blue t:instant")'
+                }
+            }
+        }
+    }
+];
+
+export async function executeToolCall(
+    name: string,
+    args: Record<string, unknown>
+): Promise<string> {
+    try {
+        return await mcpClient.callTool(name, args);
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return JSON.stringify({ error: message });
+    }
+}


### PR DESCRIPTION
## Summary
- Integrate `scryfall-mcp-server` with the GPT command to enable MTG card lookups
- Bot can now fetch card info, prices, and rulings when generating replies
- Added 5 Scryfall tools: `search_cards`, `get_card_by_name`, `get_rulings`, `get_prices_by_name`, `random_card`

## Changes
- **New:** `services/mcpClientService.ts` - MCP client wrapper with lazy connection via stdio transport
- **New:** `services/openAiToolsService.ts` - OpenAI function definitions for Scryfall tools
- **Modified:** `actions/commands/gpt.ts` - Add tool calling loop with OpenAI Responses API
- **Modified:** `index.ts` - Add MCP client cleanup on shutdown
- **Modified:** `package.json` - Add `@modelcontextprotocol/sdk` and `zod` dependencies

## Test plan
- [ ] Send a message mentioning an MTG card name to trigger GPT
- [ ] Verify GPT response includes specific card details (price, oracle text, etc.)
- [ ] Test graceful degradation when MCP server fails to connect